### PR TITLE
Fix matrix sum initialization and clarify Node pointer type

### DIFF
--- a/Math/Tests/matrix_tests.c
+++ b/Math/Tests/matrix_tests.c
@@ -610,3 +610,19 @@ void test_relu_matrix(void) {
   freeMatrix(e_m2);
 }
 
+void test_matrix_sum(void) {
+  Matrix *m = allocateMatrix(2, 2);
+
+  double data[2][2] = {
+      {1.0, 2.0},
+      {3.0, 4.0},
+  };
+  fillMatrix(m, *data);
+
+  double sum = matrix_sum(m);
+
+  CU_ASSERT_EQUAL((int)(10 * sum), (int)(10 * 10.0));
+
+  freeMatrix(m);
+}
+

--- a/Math/Tests/matrix_tests.h
+++ b/Math/Tests/matrix_tests.h
@@ -29,3 +29,4 @@ void test_hadamardProd_2x2(void);
 void test_hadamardProd_1x2(void);
 void tests_compareMatrix(void);
 void test_relu_matrix(void);
+void test_matrix_sum(void);

--- a/Math/matrix.c
+++ b/Math/matrix.c
@@ -481,7 +481,7 @@ void hadamard_prod(Matrix m1, Matrix m2, Matrix *res) {
 }
 
 double matrix_sum(Matrix *m) {
-  double res;
+  double res = 0.0;
   int r;
   int c;
 

--- a/Math/matrix.h
+++ b/Math/matrix.h
@@ -20,7 +20,7 @@ union Result {
 };
 
 struct Node {
-  struct Matrixt *ptr;
+  Matrix *ptr;
   struct Node *next;
 };
 

--- a/test_folder/Math_test_suite.c
+++ b/test_folder/Math_test_suite.c
@@ -23,6 +23,7 @@ static CU_TestInfo test_cases[] = {
     {"test_hadamardProd_1x2", test_hadamardProd_1x2},
     {"tests_compareMatrix", tests_compareMatrix},
     {"test_relu_matrix", test_relu_matrix},
+    {"test_matrix_sum", test_matrix_sum},
 
     CU_TEST_INFO_NULL,
 };

--- a/test_folder/Matrix_test_suite.c
+++ b/test_folder/Matrix_test_suite.c
@@ -22,6 +22,7 @@ static CU_TestInfo test_cases[] = {
     { "test_hadamardProd_1x2", test_hadamardProd_1x2 },
     { "tests_compareMatrix", tests_compareMatrix },
     { "test_relu_matrix", test_relu_matrix },
+    { "test_matrix_sum", test_matrix_sum },
 
     CU_TEST_INFO_NULL,
 };

--- a/utils/Matrix/Matrix.c
+++ b/utils/Matrix/Matrix.c
@@ -600,7 +600,7 @@ void hadamard_prod(Matrix m1, Matrix m2, Matrix* res)
 
 double matrix_sum(Matrix *m)
 {
-    double res;
+    double res = 0.0;
     int r;
     int c;
 

--- a/utils/Matrix/Matrix.h
+++ b/utils/Matrix/Matrix.h
@@ -21,7 +21,7 @@ union Result {
 };
 
 struct Node {
-    struct Matrixt *ptr;
+    Matrix *ptr;
     struct Node *next;
 };
 

--- a/utils/Tests/Matrix_tests.c
+++ b/utils/Tests/Matrix_tests.c
@@ -590,3 +590,17 @@ void test_relu_matrix(void)
     freeMatrix(e_m1);
     freeMatrix(e_m2);
 }
+
+void test_matrix_sum(void)
+{
+    Matrix *m = allocateMatrix(2,2);
+
+    double data[2][2] = { {1.0, 2.0}, {3.0, 4.0} };
+    fillMatrix(m, *data);
+
+    double sum = matrix_sum(m);
+
+    CU_ASSERT_EQUAL((int)(10 * sum), (int)(10 * 10.0));
+
+    freeMatrix(m);
+}

--- a/utils/Tests/Matrix_tests.h
+++ b/utils/Tests/Matrix_tests.h
@@ -26,3 +26,4 @@ void test_hadamardProd_2x2(void);
 void test_hadamardProd_1x2(void);
 void tests_compareMatrix(void);
 void test_relu_matrix(void);
+void test_matrix_sum(void);


### PR DESCRIPTION
## Summary
- initialize accumulator in matrix_sum to prevent undefined behavior
- ensure Node struct uses Matrix pointer type
- add unit tests covering matrix_sum

## Testing
- `git submodule update --init --recursive` (fails: CONNECT tunnel failed, response 403)
- `cmake -S . -B build` (fails: add_subdirectory given source "utils/cunit/CUnit" which is not an existing directory)


------
https://chatgpt.com/codex/tasks/task_e_68aec752dd688324b915c0eb0ef90d12