### PR TITLE
Provide C-based FFT with Python visualization

### DIFF
--- a/Math/CMakeLists.txt
+++ b/Math/CMakeLists.txt
@@ -7,3 +7,6 @@ if(OpenMP_C_FOUND)
 endif()
 add_library(MathFunctions matrix.c)
 target_link_libraries(MathFunctions PRIVATE OpenMP::OpenMP_C)
+
+add_library(fft SHARED fft.c)
+target_link_libraries(fft PRIVATE m)

--- a/Math/fft.c
+++ b/Math/fft.c
@@ -1,0 +1,52 @@
+#include "fft.h"
+#include <math.h>
+#include <stdlib.h>
+
+static void fft_recursive(double *real, double *imag, size_t n) {
+    if (n <= 1) {
+        return;
+    }
+    size_t half = n / 2;
+    double *real_even = (double *)malloc(half * sizeof(double));
+    double *imag_even = (double *)malloc(half * sizeof(double));
+    double *real_odd = (double *)malloc(half * sizeof(double));
+    double *imag_odd = (double *)malloc(half * sizeof(double));
+    for (size_t i = 0; i < half; ++i) {
+        real_even[i] = real[2 * i];
+        imag_even[i] = imag[2 * i];
+        real_odd[i] = real[2 * i + 1];
+        imag_odd[i] = imag[2 * i + 1];
+    }
+    fft_recursive(real_even, imag_even, half);
+    fft_recursive(real_odd, imag_odd, half);
+    for (size_t k = 0; k < half; ++k) {
+        double angle = -2.0 * M_PI * k / n;
+        double cos_a = cos(angle);
+        double sin_a = sin(angle);
+        double tr = cos_a * real_odd[k] - sin_a * imag_odd[k];
+        double ti = cos_a * imag_odd[k] + sin_a * real_odd[k];
+        real[k] = real_even[k] + tr;
+        imag[k] = imag_even[k] + ti;
+        real[k + half] = real_even[k] - tr;
+        imag[k + half] = imag_even[k] - ti;
+    }
+    free(real_even);
+    free(imag_even);
+    free(real_odd);
+    free(imag_odd);
+}
+
+void fft(double *real, double *imag, size_t n) {
+    fft_recursive(real, imag, n);
+}
+
+void ifft(double *real, double *imag, size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+        imag[i] = -imag[i];
+    }
+    fft_recursive(real, imag, n);
+    for (size_t i = 0; i < n; ++i) {
+        real[i] /= n;
+        imag[i] = -imag[i] / n;
+    }
+}

--- a/Math/fft.h
+++ b/Math/fft.h
@@ -1,0 +1,9 @@
+#ifndef M_FFT_H
+#define M_FFT_H
+
+#include <stddef.h>
+
+void fft(double *real, double *imag, size_t n);
+void ifft(double *real, double *imag, size_t n);
+
+#endif // M_FFT_H

--- a/Math/fft.py
+++ b/Math/fft.py
@@ -1,0 +1,72 @@
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+from ctypes import CDLL, c_double, c_size_t, POINTER
+
+
+_lib = None
+
+
+def _get_lib():
+    global _lib
+    if _lib is None:
+        lib_path = os.path.join(os.path.dirname(__file__), "libfft.so")
+        _lib = CDLL(lib_path)
+        _lib.fft.argtypes = [POINTER(c_double), POINTER(c_double), c_size_t]
+        _lib.ifft.argtypes = [POINTER(c_double), POINTER(c_double), c_size_t]
+    return _lib
+
+
+def fft(signal):
+    """Compute the FFT of *signal* using the C implementation."""
+    lib = _get_lib()
+    signal = np.asarray(signal, dtype=np.complex128)
+    n = signal.shape[0]
+    if n & (n - 1) != 0:
+        raise ValueError("size of signal must be a power of 2")
+    real = np.ascontiguousarray(signal.real, dtype=np.double)
+    imag = np.ascontiguousarray(signal.imag, dtype=np.double)
+    lib.fft(real.ctypes.data_as(POINTER(c_double)),
+            imag.ctypes.data_as(POINTER(c_double)),
+            n)
+    return real + 1j * imag
+
+
+def ifft(spectrum):
+    """Compute the inverse FFT of *spectrum* using the C implementation."""
+    lib = _get_lib()
+    spectrum = np.asarray(spectrum, dtype=np.complex128)
+    n = spectrum.shape[0]
+    real = np.ascontiguousarray(spectrum.real, dtype=np.double)
+    imag = np.ascontiguousarray(spectrum.imag, dtype=np.double)
+    lib.ifft(real.ctypes.data_as(POINTER(c_double)),
+             imag.ctypes.data_as(POINTER(c_double)),
+             n)
+    return real + 1j * imag
+
+
+def display_fft(signal, sample_rate):
+    """Display the magnitude spectrum of *signal* sampled at *sample_rate*.
+
+    The x-axis is logarithmic and the y-axis shows amplitude in decibels.
+    Returns the frequency bins and amplitudes in dB.
+    """
+    spectrum = fft(signal)
+    n = spectrum.size
+    freqs = np.fft.fftfreq(n, d=1.0 / sample_rate)[: n // 2]
+    magnitude = np.abs(spectrum[: n // 2])
+    magnitude_db = 20 * np.log10(np.maximum(magnitude, 1e-12))
+
+    plt.figure()
+    plt.plot(freqs, magnitude_db)
+    plt.xscale("log")
+    plt.xlabel("Frequency [Hz]")
+    plt.ylabel("Amplitude [dB]")
+    plt.title("FFT Spectrum")
+    plt.grid(True, which="both")
+    plt.show()
+
+    return freqs, magnitude_db
+
+
+__all__ = ["fft", "ifft", "display_fft"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 A showcase of algorithms can be found here: [a relative link](main.ipynb)
 
+# FFT
+
+An implementation of the Cooley–Tukey fast Fourier transform is provided in
+[`Math/fft.c`](Math/fft.c) with a small Python wrapper in
+[`Math/fft.py`](Math/fft.py).  Compile the C source to a shared library before
+use:
+
+```
+gcc -fPIC -shared Math/fft.c -o Math/libfft.so -lm
+```
+
+The Python module then exposes `fft`, `ifft` and `display_fft` functions for
+working with NumPy arrays.
+
+```
+import numpy as np
+from Math.fft import display_fft
+
+sample_rate = 48_000
+t = np.linspace(0, 1, sample_rate, endpoint=False)
+signal = np.sin(2 * np.pi * 440 * t)
+display_fft(signal, sample_rate)
+```
+
 # Build
 Build the project with "cmake --build ." in build folder
 then do "cmake .." in build folder.


### PR DESCRIPTION
## Summary
- implement recursive Cooley–Tukey FFT and inverse in C
- wrap C FFT with ctypes and retain Python visualization helper
- document build steps for C FFT and update build scripts

## Testing
- `gcc -fPIC -shared Math/fft.c -o Math/libfft.so -lm`
- `python -m py_compile Math/fft.py`
- `python - <<'PY'
import numpy as np
import matplotlib
matplotlib.use('Agg')
from Math.fft import fft, ifft, display_fft
x = np.array([0, 1, 0, -1], dtype=np.complex128)
print('fft:', fft(x))
print('ifft close:', np.allclose(ifft(fft(x)), x))
freqs, db = display_fft(x, sample_rate=4)
print('freqs:', freqs)
print('db:', db)
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy matplotlib` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68b18865e76c832491159fbed646b0a7