### PR TITLE
Add generic Q-format module with tests and integration

### DIFF
--- a/Math/CMakeLists.txt
+++ b/Math/CMakeLists.txt
@@ -5,7 +5,7 @@ if(OpenMP_C_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_C_FLAGS}")
 endif()
-add_library(MathFunctions matrix.c)
+add_library(MathFunctions matrix.c q_format.c)
 target_link_libraries(MathFunctions PRIVATE OpenMP::OpenMP_C)
 
 add_library(fft SHARED fft.c)

--- a/Math/Tests/CMakeLists.txt
+++ b/Math/Tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Math_test_lib matrix_tests.c stress_test.c)
+add_library(Math_test_lib matrix_tests.c stress_test.c q_format_tests.c)
 
 target_link_libraries(Math_test_lib PRIVATE m PUBLIC MathFunctions PRIVATE cunit)
 

--- a/Math/Tests/q_format_tests.c
+++ b/Math/Tests/q_format_tests.c
@@ -1,0 +1,43 @@
+#include "q_format_tests.h"
+
+void test_round_trip_q15(void) {
+    float values[] = {0.5f, -0.75f, 1.0f};
+    for (int i = 0; i < 3; ++i) {
+        int32_t q = to_q_format(values[i], 15);
+        float back = from_q_format(q, 15);
+        CU_ASSERT_DOUBLE_EQUAL(back, values[i], 1e-5);
+    }
+}
+
+void test_round_trip_q8(void) {
+    float values[] = {123.25f, -3.5f, 0.5f};
+    for (int i = 0; i < 3; ++i) {
+        int32_t q = to_q_format(values[i], 8);
+        float back = from_q_format(q, 8);
+        CU_ASSERT_DOUBLE_EQUAL(back, values[i], 1e-5);
+    }
+}
+
+void test_basic_arith_q15(void) {
+    int32_t a = to_q_format(0.25f, 15);
+    int32_t b = to_q_format(0.5f, 15);
+    int32_t sum = Q_ADD(a, b);
+    float fsum = from_q_format(sum, 15);
+    CU_ASSERT_DOUBLE_EQUAL(fsum, 0.75, 1e-5);
+
+    int32_t prod = Q_MUL(a, b, 15);
+    float fprod = from_q_format(prod, 15);
+    CU_ASSERT_DOUBLE_EQUAL(fprod, 0.125, 1e-5);
+}
+
+void test_basic_arith_q8(void) {
+    int32_t a = to_q_format(3.0f, 8);
+    int32_t b = to_q_format(-1.0f, 8);
+    int32_t sum = Q_ADD(a, b);
+    float fsum = from_q_format(sum, 8);
+    CU_ASSERT_DOUBLE_EQUAL(fsum, 2.0, 1e-5);
+
+    int32_t prod = Q_MUL(a, b, 8);
+    float fprod = from_q_format(prod, 8);
+    CU_ASSERT_DOUBLE_EQUAL(fprod, -3.0, 1e-5);
+}

--- a/Math/Tests/q_format_tests.h
+++ b/Math/Tests/q_format_tests.h
@@ -1,0 +1,8 @@
+#include "CUnit/Basic.h"
+#include "CUnit/CUnit.h"
+#include "q_format.h"
+
+void test_round_trip_q15(void);
+void test_round_trip_q8(void);
+void test_basic_arith_q15(void);
+void test_basic_arith_q8(void);

--- a/Math/q_format.c
+++ b/Math/q_format.c
@@ -1,0 +1,28 @@
+#include "q_format.h"
+
+int32_t to_q_format(float value, uint8_t fractional_bits) {
+    double scaling = (double)(1u << fractional_bits);
+    double max_val = (double)INT32_MAX / scaling;
+    double min_val = (double)INT32_MIN / scaling;
+
+    if (value >= max_val) {
+        return INT32_MAX;
+    }
+    if (value <= min_val) {
+        return INT32_MIN;
+    }
+
+    double scaled = value * scaling;
+    if (scaled >= 0) {
+        scaled += 0.5;
+    } else {
+        scaled -= 0.5;
+    }
+
+    return (int32_t)scaled;
+}
+
+float from_q_format(int32_t value, uint8_t fractional_bits) {
+    double scaling = (double)(1u << fractional_bits);
+    return (float)(value / scaling);
+}

--- a/Math/q_format.h
+++ b/Math/q_format.h
@@ -1,0 +1,40 @@
+#ifndef Q_FORMAT_H
+#define Q_FORMAT_H
+
+#include <stdint.h>
+#include <limits.h>
+
+int32_t to_q_format(float value, uint8_t fractional_bits);
+float from_q_format(int32_t value, uint8_t fractional_bits);
+
+static inline int32_t q_add(int32_t a, int32_t b) {
+    int64_t sum = (int64_t)a + (int64_t)b;
+    if (sum > INT32_MAX) {
+        return INT32_MAX;
+    }
+    if (sum < INT32_MIN) {
+        return INT32_MIN;
+    }
+    return (int32_t)sum;
+}
+
+static inline int32_t q_mul(int32_t a, int32_t b, uint8_t fractional_bits) {
+    int64_t prod = (int64_t)a * (int64_t)b;
+    if (fractional_bits > 0) {
+        int64_t rounding = (int64_t)1 << (fractional_bits - 1);
+        prod = (prod >= 0) ? (prod + rounding) : (prod - rounding);
+        prod >>= fractional_bits;
+    }
+    if (prod > INT32_MAX) {
+        return INT32_MAX;
+    }
+    if (prod < INT32_MIN) {
+        return INT32_MIN;
+    }
+    return (int32_t)prod;
+}
+
+#define Q_ADD(a, b) q_add((a), (b))
+#define Q_MUL(a, b, n) q_mul((a), (b), (n))
+
+#endif // Q_FORMAT_H

--- a/NN/CNN.c
+++ b/NN/CNN.c
@@ -4,6 +4,7 @@
 #include<stdint.h>
 #include<time.h>
 #include<error.h>
+#include"../Math/q_format.h"
 
 float dist[3];
 
@@ -35,12 +36,9 @@ float dReLu(float z) {
     }
 }
 
-int16_t Q15(float num) {
-    return num*pow(2,15);
-}
-
-float toQ15(int16_t num, int mult) {
-    return ((num-((pow(2,16))/2))/pow(2,15))*mult;
+#define Q15(x) (int16_t)to_q_format((x), 15)
+static inline float toQ15(int32_t num, int mult) {
+    return from_q_format(num, 15) * mult;
 }
 
 

--- a/NN/batchCNN.c
+++ b/NN/batchCNN.c
@@ -4,6 +4,7 @@
 #include<stdint.h>
 #include<time.h>
 #include<error.h>
+#include"../Math/q_format.h"
 
 float dist[3];
 
@@ -35,12 +36,9 @@ float dReLu(float z) {
     }
 }
 
-int16_t Q15(float num) {
-    return num*pow(2,15);
-}
-
-float toQ15(int16_t num, int mult) {
-    return ((num-((pow(2,16))/2))/pow(2,15))*mult;
+#define Q15(x) (int16_t)to_q_format((x), 15)
+static inline float toQ15(int32_t num, int mult) {
+    return from_q_format(num, 15) * mult;
 }
 
 

--- a/test_folder/Math_test_suite.c
+++ b/test_folder/Math_test_suite.c
@@ -1,5 +1,6 @@
 #include "matrix_tests.h"
 #include "stress_test.h"
+#include "q_format_tests.h"
 
 static CU_TestInfo test_cases[] = {
     {"test_createMatrix", test_createMatrix},
@@ -25,6 +26,10 @@ static CU_TestInfo test_cases[] = {
     {"tests_compareMatrix", tests_compareMatrix},
     {"test_relu_matrix", test_relu_matrix},
     {"test_matrix_sum", test_matrix_sum},
+    {"test_round_trip_q15", test_round_trip_q15},
+    {"test_round_trip_q8", test_round_trip_q8},
+    {"test_basic_arith_q15", test_basic_arith_q15},
+    {"test_basic_arith_q8", test_basic_arith_q8},
 
     CU_TEST_INFO_NULL,
 };


### PR DESCRIPTION
## Summary
- Introduce `q_format` utility for fixed-point conversions and saturating arithmetic.
- Add unit tests covering round-trip conversions and arithmetic for multiple Q formats.
- Replace hard-coded Q15 helpers in CNN modules with calls to `q_format` and wire module into build system.

## Testing
- `gcc /tmp/temp_q_format_test.c Algorithms/Math/q_format.c -I Algorithms/Math -lm && ./a.out`
- `cmake -S Algorithms -B build` *(fails: add_subdirectory given source "utils/cunit/CUnit" which is not an existing directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b197b4d03c8324b7fca02b6f855768